### PR TITLE
Support additional time formats

### DIFF
--- a/app.js
+++ b/app.js
@@ -105,7 +105,7 @@ function* setDay(context, day) {
 function* setTime(context, time) {
   time = (time || '').trim();
 
-  var target = moment(time, ['HH:mm', 'hh:mm a', 'hh:mma'], true);
+  var target = moment(time, ['H:mm', 'h:mm a', 'h:mma'], true);
   var emoticon,
     color;
 


### PR DESCRIPTION
#9 Fix issue where time formats require 2 digit hour instead of allowing 1 or 2 digit hours